### PR TITLE
Fix import handling for BeautifulSoup

### DIFF
--- a/ANKI_to_PDF.py
+++ b/ANKI_to_PDF.py
@@ -6,7 +6,6 @@ import argparse
 import os
 import io
 import re
-from bs4 import BeautifulSoup # Pro parsování HTML
 from reportlab.platypus import (SimpleDocTemplate, Paragraph, Spacer, Image,
                                 PageBreak, Flowable)
 from reportlab.lib.styles import getSampleStyleSheet, ParagraphStyle
@@ -68,10 +67,11 @@ class ResizableImage(Flowable):
                 print(f"   ERROR: Chyba při vykreslování obrázku: {e}")
 
 def parse_html_content(html_text):
-    """ Analyzuje HTML obsah pole, extrahuje text a názvy obrázkových souborů. """
+    """Analyzuje HTML obsah pole, extrahuje text a názvy obrázkových souborů."""
     if not html_text:
         return "", []
     try:
+        from bs4 import BeautifulSoup
         soup = BeautifulSoup(html_text, 'html.parser')
     except Exception as e:
         print(f"   WARN: Chyba při parsování HTML: {e}. Obsah pole: {html_text[:100]}...")


### PR DESCRIPTION
## Summary
- remove global bs4 import
- import BeautifulSoup lazily inside `parse_html_content`
- keep import check in `main` so the error message still appears

## Testing
- `python3 -m py_compile ANKI_to_PDF.py`
- `python3 ANKI_to_PDF.py TestDeck output.pdf` *(fails to connect to AnkiConnect)*

------
https://chatgpt.com/codex/tasks/task_e_6840388c48ac8328911420949c78bac4