### PR TITLE
Avoid PDF/A during OCR

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+requests
+beautifulsoup4
+reportlab
+ocrmypdf


### PR DESCRIPTION
## Summary
- prevent Ghostscript rangecheck errors by disabling PDF/A output

## Testing
- `python3 -m py_compile ANKI_to_PDF.py`
- `python3 - <<'EOF'
from ANKI_to_PDF import create_pdf_connect
cards_data = [{'note_id':1,'model_name':'Model','q_text':'Hello','q_images':[],'a_text':'World','a_images':[]}]
create_pdf_connect(cards_data, 'out.pdf')
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6840388c48ac8328911420949c78bac4