### PR TITLE
Fix OCR indentation error

### DIFF
--- a/ANKI_to_PDF.py
+++ b/ANKI_to_PDF.py
@@ -318,16 +318,21 @@ def apply_ocr_to_pdf(pdf_path, lang="ces"):
         return
 
     temp_output = pdf_path + ".ocr.tmp.pdf"
-try:
-    # Avoid PDF/A conversion which can fail on very large documents
-    ocrmypdf.ocr(pdf_path, temp_output, language=lang, force_ocr=True,
-                 output_type="pdf")
-    os.replace(temp_output, pdf_path)
-    print(f"INFO: OCR dokončeno: {pdf_path}")
-except Exception as e:
-    print(f"ERROR: Chyba při provádění OCR: {e}")
-    if os.path.exists(temp_output):
-        os.remove(temp_output)
+    try:
+        # Avoid PDF/A conversion which can fail on very large documents
+        ocrmypdf.ocr(
+            pdf_path,
+            temp_output,
+            language=lang,
+            force_ocr=True,
+            output_type="pdf",
+        )
+        os.replace(temp_output, pdf_path)
+        print(f"INFO: OCR dokončeno: {pdf_path}")
+    except Exception as e:
+        print(f"ERROR: Chyba při provádění OCR: {e}")
+        if os.path.exists(temp_output):
+            os.remove(temp_output)
 
 
 def main():


### PR DESCRIPTION
## Summary
- fix indentation of OCR call so it executes inside `apply_ocr_to_pdf`

## Testing
- `python -m py_compile ANKI_to_PDF.py`
- `python ANKI_to_PDF.py "dummy" output.pdf` *(fails to connect to Anki)*

------
https://chatgpt.com/codex/tasks/task_e_6842ec5b6aa48328a6387296a5d4a277