### PR TITLE
Improve OCR handling

### DIFF
--- a/ANKI_to_PDF.py
+++ b/ANKI_to_PDF.py
@@ -360,12 +360,14 @@ def apply_ocr_to_pdf(pdf_path, lang="ces"):
 
     temp_output = pdf_path + ".ocr.tmp.pdf"
     try:
-        # Avoid PDF/A conversion which can fail on very large documents
+        # Use skip_text to avoid rasterizing pages that already contain text
+        # and enable optimization to keep the output size reasonable
         ocrmypdf.ocr(
             pdf_path,
             temp_output,
             language=lang,
-            force_ocr=True,
+            skip_text=True,
+            optimize=3,
             output_type="pdf",
         )
         os.replace(temp_output, pdf_path)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ANKI to PDF
 
-This repository contains a script to export Anki decks to PDF via AnkiConnect. If the optional `ocrmypdf` package is installed, OCR will be performed on the generated PDF.
+This repository contains a script to export Anki decks to PDF via AnkiConnect. If the optional `ocrmypdf` package is installed, the script can run OCR on the generated PDF. Pages that already contain text are skipped to avoid unnecessary rasterization.
 
 ## Setup
 
@@ -17,7 +17,7 @@ Install the required packages:
 pip install -r requirements.txt
 ```
 
-The `ocrmypdf` package is listed in `requirements.txt`. It enables OCR when the script generates the PDF. If it is not installed, the script skips the OCR step.
+The `ocrmypdf` package is listed in `requirements.txt`. It enables optional OCR when the script generates the PDF. Pages that already contain text are skipped by default, so OCR typically does not inflate the file size. If `ocrmypdf` is not installed, the script simply skips this step.
 
 ## Usage
 


### PR DESCRIPTION
## Summary
- avoid rasterizing pages that already contain text by enabling `skip_text`
- add optimization level when running `ocrmypdf`
- document new OCR behavior in README

## Testing
- `python -m py_compile ANKI_to_PDF.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843f1d4edb08328894a3427a57edd50