### PR TITLE
Add automatic OCR retry with force option

### DIFF
--- a/ANKI_to_PDF.py
+++ b/ANKI_to_PDF.py
@@ -396,7 +396,26 @@ def apply_ocr_to_pdf(pdf_path, lang="ces", force=False):
         os.replace(temp_output, pdf_path)
         print(f"INFO: OCR dokončeno: {pdf_path}")
     except Exception as e:
-        print(f"ERROR: Chyba při provádění OCR: {e}")
+        # If OCR failed because the PDF already contains text, retry with force
+        if "page already has text" in str(e).lower() and not force:
+            print("INFO: PDF již obsahuje text. Opakuji OCR s volbou --force-ocr.")
+            try:
+                ocrmypdf.ocr(
+                    pdf_path,
+                    temp_output,
+                    language=lang,
+                    skip_text=False,
+                    force_ocr=True,
+                    optimize=3,
+                    output_type="pdf",
+                )
+                os.replace(temp_output, pdf_path)
+                print(f"INFO: OCR dokončeno s --force-ocr: {pdf_path}")
+                return
+            except Exception as e2:
+                print(f"ERROR: OCR s --force-ocr selhalo: {e2}")
+        else:
+            print(f"ERROR: Chyba při provádění OCR: {e}")
         if os.path.exists(temp_output):
             os.remove(temp_output)
 

--- a/README.md
+++ b/README.md
@@ -28,4 +28,4 @@ force options can be provided via flags:
 python ANKI_to_PDF.py "My Deck" output.pdf --ocr-lang "ces+chi_sim" --force-ocr
 ```
 
-The script will connect to Anki using AnkiConnect, export the selected deck and save it to `output.pdf`.
+The script will connect to Anki using AnkiConnect, export the selected deck and save it to `output.pdf`. If OCR fails because the PDF already contains text, it automatically retries with the `--force-ocr` option.


### PR DESCRIPTION
## Summary
- retry OCR with `--force-ocr` if initial run fails because text already exists
- update README usage section to note the automatic retry

## Testing
- `python -m py_compile ANKI_to_PDF.py`
- `pip install -r requirements.txt`
- `python ANKI_to_PDF.py --help | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6844322b3a208328a64cbef573243981